### PR TITLE
extract YANG modules from RFCs/IDs only if marked with <CODE BEGINS>

### DIFF
--- a/rfcstrip
+++ b/rfcstrip
@@ -32,6 +32,8 @@
 # and getopts (shell builtin like in bash or standalone).
 #
 # History:
+#   1.3 - 2020-08-23
+#       extract YANG modules only if prepended by <CODE BEGINS>
 #   1.2 - 2020-03-31
 #       added option to extract and unfold artwork from xml files
 #   1.1 - 2019-11-08
@@ -51,7 +53,7 @@
 #   0.3 - 2018-05-17
 #       handle -f option
 
-VERSION=1.2
+VERSION=1.3
 
 AWK=awk
 GETOPTS=getopts

--- a/rfcstrip
+++ b/rfcstrip
@@ -170,7 +170,7 @@ do_strip_txt() {
 
     # start of YANG module
     type == 0 &&
-    /^[ \t]*(sub)?module +([A-Za-z0-9-]*) *{ *$/ {
+    /^[ \t]*<CODE BEGINS>[ \t]*(sub)?module +([A-Za-z0-9-]*) *{ *$/ {
         module = $2
         file = module".yang"
         modindent = match($0, "[^ \t]")


### PR DESCRIPTION
Hi
there are cases like this:
draft-ietf-teas-yang-te-topo-22.txt
that embed YANG modules which are just examples and lack the <CODE BEGINS> marker.
They are not guaranteed to work.
rfcstrip 1.2 still extract them and this messes up subsequent validation.
I suggest to extract YANG modules only if marked with <CODE BEGINS>.
Kind regards
Gianmarco